### PR TITLE
Export previous CSAP contacts to advertise IOM to

### DIFF
--- a/export_contact_lists.py
+++ b/export_contact_lists.py
@@ -1,0 +1,90 @@
+import argparse
+import csv
+import json
+
+from core_data_modules.cleaners import Codes
+from core_data_modules.logging import Logger
+from core_data_modules.traced_data import TracedData
+from core_data_modules.traced_data.io import TracedDataJsonIO
+from core_data_modules.util import PhoneNumberUuidTable
+from id_infrastructure.firestore_uuid_table import FirestoreUuidTable
+from storage.google_cloud import google_cloud_utils
+
+from src.lib import PipelineConfiguration
+from src.lib.code_schemes import CodeSchemes
+
+Logger.set_project_name("IOM")
+log = Logger(__name__)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generates lists of phone numbers of previous CSAP respondents who  "
+                                                 "were labelled as living in ")
+
+    parser.add_argument("traced_data_path", metavar="traced-data-path",
+                        help="Path to the traced data file (either messages or individuals) to extract phone "
+                             "numbers from")
+    parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
+                        help="Path to a Google Cloud service account credentials file to use to access the "
+                             "credentials bucket")
+    parser.add_argument("pipeline_configuration_file_path", metavar="pipeline-configuration-file",
+                        help="Path to the pipeline configuration json file")
+
+    args = parser.parse_args()
+
+    traced_data_path = args.traced_data_path
+    google_cloud_credentials_file_path = args.google_cloud_credentials_file_path
+    pipeline_configuration_file_path = args.pipeline_configuration_file_path
+
+    iom_locations = {"cabudwaaq", "gaalkacyo", "dhuusamarreeb"}
+
+    log.info("Loading Pipeline Configuration File...")
+    with open(pipeline_configuration_file_path) as f:
+        pipeline_configuration = PipelineConfiguration.from_configuration_file(f)
+
+    log.info("Downloading Firestore UUID Table credentials...")
+    firestore_uuid_table_credentials = json.loads(google_cloud_utils.download_blob_to_string(
+        google_cloud_credentials_file_path,
+        pipeline_configuration.phone_number_uuid_table.firebase_credentials_file_url
+    ))
+
+    phone_number_uuid_table = FirestoreUuidTable(
+        pipeline_configuration.phone_number_uuid_table.table_name,
+        firestore_uuid_table_credentials,
+        "avf-phone-uuid-"
+    )
+    log.info("Initialised the Firestore UUID table")
+
+    # Load the traced data
+    log.info(f"Loading previous traced data from file '{traced_data_path}'...")
+    with open(traced_data_path) as f:
+        data = TracedDataJsonIO.import_jsonl_to_traced_data_iterable(f)
+    log.info(f"Loaded {len(data)} traced data objects")
+
+    # Search the TracedData for contacts from relevant locations
+    uuids = set()
+    log.info(f"Searching for participants from the IOM target locations ({iom_locations})")
+    for td in data:
+        if td["district_coded"] == Codes.STOP:
+            continue
+
+        if CodeSchemes.SOMALIA_DISTRICT.get_code_with_code_id(td["district_coded"]["CodeID"]).string_value in iom_locations:
+            uuids.add(td["uid"])
+    log.info(f"Found {len(uuids)} contacts in the IOM target locations")
+
+    # Convert the uuids to phone numbers
+    log.info("Converting the uuids to phone numbers...")
+    uuid_phone_number_lut = phone_number_uuid_table.uuid_to_data_batch(uuids)
+    phone_numbers = {f"+{uuid_phone_number_lut[uuid]}" for uuid in uuids}
+
+    # Export CSVs
+    csv_path = 'test.csv'
+    log.warning(f"Exporting {len(phone_numbers)} phone numbers to {csv_path}...")
+    with open(csv_path, "w") as f:
+        writer = csv.DictWriter(f, fieldnames=["URN:Tel", "Name"], lineterminator="\n")
+        writer.writeheader()
+
+        for n in phone_numbers:
+            writer.writerow({
+                "URN:Tel": n
+            })
+        log.info(f"Wrote {len(phone_numbers)} contacts to {csv_path}")

--- a/export_contact_lists.py
+++ b/export_contact_lists.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     uuid_phone_number_lut = phone_number_uuid_table.uuid_to_data_batch(uuids)
     phone_numbers = {f"+{uuid_phone_number_lut[uuid]}" for uuid in uuids}
 
-    # Export CSVs
+    # Export contacts CSV
     log.warning(f"Exporting {len(phone_numbers)} phone numbers to {csv_output_file_path}...")
     with open(csv_output_file_path, "w") as f:
         writer = csv.DictWriter(f, fieldnames=["URN:Tel", "Name"], lineterminator="\n")

--- a/export_contact_lists.py
+++ b/export_contact_lists.py
@@ -28,12 +28,16 @@ if __name__ == "__main__":
     parser.add_argument("traced_data_paths", metavar="traced-data-paths", nargs="+",
                         help="Paths to the traced data files (either messages or individuals) to extract phone "
                              "numbers from")
+    parser.add_argument("csv_output_file_path", metavar="csv-output-file-path",
+                        help="Path to a CSV file to write the contacts from the districts of interest to. "
+                             "Exported file is in a format suitable for direct upload to Rapid Pro")
 
     args = parser.parse_args()
 
     google_cloud_credentials_file_path = args.google_cloud_credentials_file_path
     pipeline_configuration_file_path = args.pipeline_configuration_file_path
     traced_data_paths = args.traced_data_paths
+    csv_output_file_path = args.csv_output_file_path
 
     log.info("Loading Pipeline Configuration File...")
     with open(pipeline_configuration_file_path) as f:
@@ -78,9 +82,8 @@ if __name__ == "__main__":
     phone_numbers = {f"+{uuid_phone_number_lut[uuid]}" for uuid in uuids}
 
     # Export CSVs
-    csv_path = 'test.csv'
-    log.warning(f"Exporting {len(phone_numbers)} phone numbers to {csv_path}...")
-    with open(csv_path, "w") as f:
+    log.warning(f"Exporting {len(phone_numbers)} phone numbers to {csv_output_file_path}...")
+    with open(csv_output_file_path, "w") as f:
         writer = csv.DictWriter(f, fieldnames=["URN:Tel", "Name"], lineterminator="\n")
         writer.writeheader()
 
@@ -88,4 +91,4 @@ if __name__ == "__main__":
             writer.writerow({
                 "URN:Tel": n
             })
-        log.info(f"Wrote {len(phone_numbers)} contacts to {csv_path}")
+        log.info(f"Wrote {len(phone_numbers)} contacts to {csv_output_file_path}")

--- a/export_contact_lists.py
+++ b/export_contact_lists.py
@@ -56,9 +56,9 @@ if __name__ == "__main__":
     )
     log.info("Initialised the Firestore UUID table")
 
-    # Load the traced data
     uuids = set()
     for path in traced_data_paths:
+        # Load the traced data
         log.info(f"Loading previous traced data from file '{path}'...")
         with open(path) as f:
             data = TracedDataJsonIO.import_jsonl_to_traced_data_iterable(f)

--- a/export_contact_lists.py
+++ b/export_contact_lists.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
             data = TracedDataJsonIO.import_jsonl_to_traced_data_iterable(f)
         log.info(f"Loaded {len(data)} traced data objects")
 
-        # Search the TracedData for contacts from relevant locations
+        # Search the TracedData for contacts from one of the relevant locations
         log.info(f"Searching for participants from the IOM target locations ({IOM_LOCATIONS})")
         file_uuids = set()
         for td in data:

--- a/export_contact_lists.py
+++ b/export_contact_lists.py
@@ -14,6 +14,8 @@ from src.lib.code_schemes import CodeSchemes
 Logger.set_project_name("IOM")
 log = Logger(__name__)
 
+IOM_LOCATIONS = {"cabudwaaq", "gaalkacyo", "dhuusamarreeb"}
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generates lists of phone numbers of previous CSAP respondents who  "
                                                  "were labelled as living in ")
@@ -32,8 +34,6 @@ if __name__ == "__main__":
     google_cloud_credentials_file_path = args.google_cloud_credentials_file_path
     pipeline_configuration_file_path = args.pipeline_configuration_file_path
     traced_data_paths = args.traced_data_paths
-
-    iom_locations = {"cabudwaaq", "gaalkacyo", "dhuusamarreeb"}
 
     log.info("Loading Pipeline Configuration File...")
     with open(pipeline_configuration_file_path) as f:
@@ -61,13 +61,13 @@ if __name__ == "__main__":
         log.info(f"Loaded {len(data)} traced data objects")
 
         # Search the TracedData for contacts from relevant locations
-        log.info(f"Searching for participants from the IOM target locations ({iom_locations})")
+        log.info(f"Searching for participants from the IOM target locations ({IOM_LOCATIONS})")
         file_uuids = set()
         for td in data:
             if td["district_coded"] == Codes.STOP:
                 continue
 
-            if CodeSchemes.SOMALIA_DISTRICT.get_code_with_code_id(td["district_coded"]["CodeID"]).string_value in iom_locations:
+            if CodeSchemes.SOMALIA_DISTRICT.get_code_with_code_id(td["district_coded"]["CodeID"]).string_value in IOM_LOCATIONS:
                 file_uuids.add(td["uid"])
         uuids.update(file_uuids)
         log.info(f"Found {len(file_uuids)} contacts in the IOM target locations (running total: {len(uuids)})")

--- a/export_contact_lists.py
+++ b/export_contact_lists.py
@@ -18,7 +18,7 @@ IOM_LOCATIONS = {"cabudwaaq", "gaalkacyo", "dhuusamarreeb"}
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generates lists of phone numbers of previous CSAP respondents who  "
-                                                 "were labelled as living in ")
+                                                 "were labelled as living in one of the IOM target districts")
 
     parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
                         help="Path to a Google Cloud service account credentials file to use to access the "

--- a/export_contact_lists.py
+++ b/export_contact_lists.py
@@ -4,9 +4,7 @@ import json
 
 from core_data_modules.cleaners import Codes
 from core_data_modules.logging import Logger
-from core_data_modules.traced_data import TracedData
 from core_data_modules.traced_data.io import TracedDataJsonIO
-from core_data_modules.util import PhoneNumberUuidTable
 from id_infrastructure.firestore_uuid_table import FirestoreUuidTable
 from storage.google_cloud import google_cloud_utils
 


### PR DESCRIPTION
Adapted from https://github.com/AfricasVoices/Project-UNDP-RCO/blob/master/export_adss_contact_lists.py, but modified to search for IOM districts rather than UNDP-RCO, and to support loading contacts from multiple traced data files.