### PR TITLE
Update analysis_file.py and dependencies to match OCHA

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "v0.12.1"}
+CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "v0.13.0"}
 PipelineInfrastructure = {editable = true,git = "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",ref = "v0.0.4"}
 RapidProTools = {editable = true,git = "https://www.github.com/AfricasVoices/RapidProTools",ref = "v0.3.2"}
 pytz = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b4dad92dee09c5b9235785cc803157eed0347cf39c6ea6034dfaf3e5681a3a1d"
+            "sha256": "ebeccb8934ad185878d56bb56c47cfbb45587a76a35e5ff4213c3b3021633bb2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -62,7 +62,7 @@
         "coredatamodules": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/CoreDataModules",
-            "ref": "3498e368919a97d0cb8d89e22e06c3aac7f1d35e"
+            "ref": "25c806befdaa624a035fa15f6db09f71ed2ba7ba"
         },
         "deprecation": {
             "hashes": [

--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -1,63 +1,19 @@
-import sys
-import time
+from collections import OrderedDict
 
 from core_data_modules.cleaners import Codes
 from core_data_modules.traced_data import Metadata
 from core_data_modules.traced_data.io import TracedDataCSVIO
 from core_data_modules.traced_data.util import FoldTracedData
+from core_data_modules.traced_data.util.fold_traced_data import FoldStrategies
 from core_data_modules.util import TimeUtils
 
 from src.lib import PipelineConfiguration, ConsentUtils
-from src.lib.pipeline_configuration import CodingModes, FoldingModes
+from src.lib.pipeline_configuration import CodingModes
 
 
 class AnalysisFile(object):
     @staticmethod
-    def generate(user, data, csv_by_message_output_path, csv_by_individual_output_path):
-        # Serializer is currently overflowing
-        # TODO: Investigate/address the cause of this.
-        sys.setrecursionlimit(15000)
-
-        consent_withdrawn_key = "consent_withdrawn"
-        for td in data:
-            td.append_data({consent_withdrawn_key: Codes.FALSE},
-                           Metadata(user, Metadata.get_call_location(), time.time()))
-
-        # Set the list of keys to be exported and how they are to be handled when folding
-        export_keys = ["uid", consent_withdrawn_key]
-        bool_keys = [consent_withdrawn_key]
-        equal_keys = ["uid"]
-        concat_keys = []
-        matrix_keys = []
-        binary_keys = []
-        for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
-            for cc in plan.coding_configurations:
-                if cc.analysis_file_key is None:
-                    continue
-
-                if cc.coding_mode == CodingModes.SINGLE:
-                    export_keys.append(cc.analysis_file_key)
-
-                    if cc.folding_mode == FoldingModes.ASSERT_EQUAL:
-                        equal_keys.append(cc.analysis_file_key)
-                    elif cc.folding_mode == FoldingModes.YES_NO_AMB:
-                        binary_keys.append(cc.analysis_file_key)
-                    else:
-                        assert False, f"Incompatible folding_mode {plan.folding_mode}"
-                else:
-                    assert cc.folding_mode == FoldingModes.MATRIX
-                    for code in cc.code_scheme.codes:
-                        export_keys.append(f"{cc.analysis_file_key}{code.string_value}")
-                        matrix_keys.append(f"{cc.analysis_file_key}{code.string_value}")
-
-            export_keys.append(plan.raw_field)
-            if plan.raw_field_folding_mode == FoldingModes.CONCATENATE:
-                concat_keys.append(plan.raw_field)
-            elif plan.raw_field_folding_mode == FoldingModes.ASSERT_EQUAL:
-                equal_keys.append(plan.raw_field)
-            else:
-                assert False, f"Incompatible raw_field_folding_mode {plan.raw_field_folding_mode}"
-
+    def export_to_csv(user, data, csv_path, export_keys, consent_withdrawn_key):
         # Convert codes to their string/matrix values
         for td in data:
             analysis_dict = dict()
@@ -75,8 +31,8 @@ class AnalysisFile(object):
                         for code in cc.code_scheme.codes:
                             show_matrix_keys.append(f"{cc.analysis_file_key}{code.string_value}")
 
-                        for label in td.get(cc.coded_field, []):
-                            code_string_value = cc.code_scheme.get_code_with_code_id(label['CodeID']).string_value
+                        for label in td[cc.coded_field]:
+                            code_string_value = cc.code_scheme.get_code_with_code_id(label["CodeID"]).string_value
                             analysis_dict[f"{cc.analysis_file_key}{code_string_value}"] = Codes.MATRIX_1
 
                         for key in show_matrix_keys:
@@ -85,11 +41,48 @@ class AnalysisFile(object):
             td.append_data(analysis_dict,
                            Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
+        # Hide data from participants who opted out
+        ConsentUtils.set_stopped(user, data, consent_withdrawn_key, additional_keys=export_keys)
+
+        with open(csv_path, "w") as f:
+            TracedDataCSVIO.export_traced_data_iterable_to_csv(data, f, headers=export_keys)
+
+    @classmethod
+    def generate(cls, user, data, csv_by_message_output_path, csv_by_individual_output_path):
+        # Serializer is currently overflowing
+        # TODO: Investigate/address the cause of this.
+        # sys.setrecursionlimit(15000)
+
         # Set consent withdrawn based on presence of data coded as "stop"
+        consent_withdrawn_key = "consent_withdrawn"
         ConsentUtils.determine_consent_withdrawn(
             user, data, PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS,
             consent_withdrawn_key
         )
+
+        # Set the list of keys to be exported and how they are to be handled when folding
+        fold_strategies = OrderedDict()
+        fold_strategies["uid"] = FoldStrategies.assert_equal
+        fold_strategies[consent_withdrawn_key] = FoldStrategies.boolean_or
+
+        export_keys = ["uid", consent_withdrawn_key]
+
+        for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
+            for cc in plan.coding_configurations:
+                if cc.analysis_file_key is None:
+                    continue
+
+                if cc.coding_mode == CodingModes.SINGLE:
+                    export_keys.append(cc.analysis_file_key)
+                else:
+                    assert cc.coding_mode == CodingModes.MULTIPLE
+                    for code in cc.code_scheme.codes:
+                        export_keys.append(f"{cc.analysis_file_key}{code.string_value}")
+
+                fold_strategies[cc.coded_field] = cc.fold_strategy
+
+            export_keys.append(plan.raw_field)
+            fold_strategies[plan.raw_field] = plan.raw_field_fold_strategy
 
         # Fold data to have one respondent per row
         to_be_folded = []
@@ -97,43 +90,10 @@ class AnalysisFile(object):
             to_be_folded.append(td.copy())
 
         folded_data = FoldTracedData.fold_iterable_of_traced_data(
-            user, data, fold_id_fn=lambda td: td["uid"],
-            equal_keys=equal_keys, concat_keys=concat_keys, matrix_keys=matrix_keys, bool_keys=bool_keys,
-            binary_keys=binary_keys
+            user, to_be_folded, lambda td: td["uid"], fold_strategies
         )
 
-        # Fix-up _NA and _NC keys, which are currently being set incorrectly by
-        # FoldTracedData.fold_iterable_of_traced_data when there are multiple radio shows
-        # TODO: Update FoldTracedData to handle NA and NC correctly under multiple radio shows
-        for td in folded_data:
-            for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
-                for cc in plan.coding_configurations:
-                    if cc.analysis_file_key is None:
-                        continue
-
-                    if cc.coding_mode == CodingModes.MULTIPLE:
-                        if td.get(plan.raw_field, "") != "":
-                            td.append_data({f"{cc.analysis_file_key}{Codes.TRUE_MISSING}": Codes.MATRIX_0},
-                                           Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
-
-                        contains_non_nc_key = False
-                        for key in matrix_keys:
-                            if key.startswith(cc.analysis_file_key) and not key.endswith(Codes.NOT_CODED) \
-                                    and td.get(key) == Codes.MATRIX_1:
-                                contains_non_nc_key = True
-                        if not contains_non_nc_key:
-                            td.append_data({f"{cc.analysis_file_key}{Codes.NOT_CODED}": Codes.MATRIX_1},
-                                           Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
-
-        # Process consent
-        ConsentUtils.set_stopped(user, data, consent_withdrawn_key, additional_keys=export_keys)
-        ConsentUtils.set_stopped(user, folded_data, consent_withdrawn_key, additional_keys=export_keys)
-
-        # Output to CSV with one message per row
-        with open(csv_by_message_output_path, "w") as f:
-            TracedDataCSVIO.export_traced_data_iterable_to_csv(data, f, headers=export_keys)
-
-        with open(csv_by_individual_output_path, "w") as f:
-            TracedDataCSVIO.export_traced_data_iterable_to_csv(folded_data, f, headers=export_keys)
+        cls.export_to_csv(user, data, csv_by_message_output_path, export_keys, consent_withdrawn_key)
+        cls.export_to_csv(user, folded_data, csv_by_individual_output_path, export_keys, consent_withdrawn_key)
 
         return data, folded_data

--- a/src/lib/consent_utils.py
+++ b/src/lib/consent_utils.py
@@ -25,17 +25,18 @@ class ConsentUtils(object):
                     if cc.code_scheme.get_code_with_code_id(td[cc.coded_field]["CodeID"]).control_code == Codes.STOP:
                         return True
                 else:
-                    if td[f"{cc.analysis_file_key}{Codes.STOP}"] == Codes.MATRIX_1:
-                        return True
+                    for label in td[cc.coded_field]:
+                        if cc.code_scheme.get_code_with_code_id(label["CodeID"]).control_code == Codes.STOP:
+                            return True
         return False
 
     @classmethod
     def determine_consent_withdrawn(cls, user, data, coding_plans, withdrawn_key="consent_withdrawn"):
         """
-        Determines whether consent has been withdrawn, by searching for Codes.STOP in the given list of keys.
+        Determines whether consent has been withdrawn, by searching for Codes.STOP in the given list of coding plans.
 
         TracedData objects where a stop code is found will have the key-value pair <withdrawn_key>: Codes.TRUE
-        appended. Objects where a stop code is not found are not modified.
+        appended, or Codes.FALSE if no stop code is found.
 
         Note that this does not actually set any other keys to Codes.STOP. Use Consent.set_stopped for this purpose.
 
@@ -43,11 +44,14 @@ class ConsentUtils(object):
         :type user: str
         :param data: TracedData objects to determine consent for.
         :type data: iterable of TracedData
-        :param coding_plans:
+        :param coding_plans: Coding plans for the fields to search for stop codes.
         :type coding_plans: iterable of CodingPlan
         :param withdrawn_key: Name of key to use for the consent withdrawn field.
         :type withdrawn_key: str
         """
+        for td in data:
+            td.append_data({withdrawn_key: Codes.FALSE}, Metadata(user, Metadata.get_call_location(), time.time()))
+
         stopped_uids = set()
         for td in data:
             if cls.td_has_stop_code(td, coding_plans):


### PR DESCRIPTION
This updates IOM to bring it in line with a number of improvements to OCHA and Core Data. Collectively, these simplify the pipeline code base slightly while enabling compatibility with future automated analysis work.

More specifically, this PR contains these changes (PR on which the change is based in brackets):
 - Updates Core to v0.13.0, which changes the implementation of folding to be easier to use and more extensible (https://github.com/AfricasVoices/CoreDataModules/releases/tag/v0.13.0)
 - Folds the labels then converts to string/matrix representation, rather than converting then folding. This removes the need for clean-up code, and means we preserve labels in the TracedData, which we can then use for the new automated analysis. (https://github.com/AfricasVoices/Project-OCHA/pull/77, https://github.com/AfricasVoices/Project-OCHA/pull/73, https://github.com/AfricasVoices/Project-OCHA/pull/70)
 - Replaces FoldingModes with direct calls to FoldStrategies (https://github.com/AfricasVoices/Project-OCHA/pull/80)
 - Moves all the consent detection logic into the same place (https://github.com/AfricasVoices/Project-OCHA/pull/81)

Tested in the usual way, by running master and this branch's generate_outputs stage over the same data and checking that the outputs are the same with diff.