### PR TITLE
Set the Logger's project_name field by reading from the configuration file

### DIFF
--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -20,7 +20,6 @@ from temba_client.v2 import Contact, Run
 from src.lib import PipelineConfiguration, CodeSchemes
 from src.lib.pipeline_configuration import RapidProSource, GCloudBucketSource, ShaqadoonCSVSource
 
-Logger.set_project_name("IOM")
 log = Logger(__name__)
 
 
@@ -198,6 +197,8 @@ def main(user, google_cloud_credentials_file_path, pipeline_configuration_file_p
     log.info("Loading Pipeline Configuration File...")
     with open(pipeline_configuration_file_path) as f:
         pipeline_configuration = PipelineConfiguration.from_configuration_file(f)
+    Logger.set_project_name(pipeline_configuration.pipeline_name)
+    log.debug(f"Pipeline name is {pipeline_configuration.pipeline_name}")
 
     log.info("Downloading Firestore UUID Table credentials...")
     firestore_uuid_table_credentials = json.loads(google_cloud_utils.download_blob_to_string(

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -14,7 +14,6 @@ from storage.google_drive import drive_client_wrapper
 from src.lib import PipelineConfiguration
 from src.lib.pipeline_configuration import CodingModes
 
-Logger.set_project_name("IOM")
 log = Logger(__name__)
 
 IMG_SCALE_FACTOR = 10  # Increase this to increase the resolution of the outputted PNGs
@@ -51,6 +50,8 @@ if __name__ == "__main__":
     log.info("Loading Pipeline Configuration File...")
     with open(pipeline_configuration_file_path) as f:
         pipeline_configuration = PipelineConfiguration.from_configuration_file(f)
+    Logger.set_project_name(pipeline_configuration.pipeline_name)
+    log.debug(f"Pipeline name is {pipeline_configuration.pipeline_name}")
 
     if pipeline_configuration.drive_upload is not None:
         log.info(f"Downloading Google Drive service account credentials...")

--- a/generate_outputs.py
+++ b/generate_outputs.py
@@ -12,7 +12,6 @@ from src import CombineRawDatasets, TranslateRapidProKeys, AutoCode, ProductionF
     ApplyManualCodes, AnalysisFile, WSCorrection
 from src.lib import PipelineConfiguration
 
-Logger.set_project_name("IOM")
 log = Logger(__name__)
 
 if __name__ == "__main__":
@@ -74,6 +73,8 @@ if __name__ == "__main__":
     log.info("Loading Pipeline Configuration File...")
     with open(pipeline_configuration_file_path) as f:
         pipeline_configuration = PipelineConfiguration.from_configuration_file(f)
+    Logger.set_project_name(pipeline_configuration.pipeline_name)
+    log.debug(f"Pipeline name is {pipeline_configuration.pipeline_name}")
 
     if pipeline_configuration.drive_upload is not None:
         log.info(f"Downloading Google Drive service account credentials...")

--- a/pipeline_config.json
+++ b/pipeline_config.json
@@ -1,4 +1,5 @@
 {
+  "PipelineName": "IOM",
   "RawDataSources": [
     {
       "SourceType": "RapidPro",

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -231,10 +231,12 @@ class PipelineConfiguration(object):
                    raw_field_fold_strategy=FoldStrategies.assert_equal)
     ]
 
-    def __init__(self, raw_data_sources, phone_number_uuid_table, timestamp_remappings,
+    def __init__(self, pipeline_name, raw_data_sources, phone_number_uuid_table, timestamp_remappings,
                  rapid_pro_key_remappings, project_start_date, project_end_date, filter_test_messages, move_ws_messages,
                  memory_profile_upload_url_prefix, data_archive_upload_url_prefix, drive_upload=None):
         """
+        :param pipeline_name: The name of this pipeline.
+        :type pipeline_name: str
         :param raw_data_sources: List of sources to pull the various raw run files from.
         :type raw_data_sources: list of RawDataSource
         :param phone_number_uuid_table: Configuration for the Firestore phone number <-> uuid table.
@@ -259,6 +261,7 @@ class PipelineConfiguration(object):
                              If None, does not upload to Google Drive.
         :type drive_upload: DriveUploadPaths | None
         """
+        self.pipeline_name = pipeline_name
         self.raw_data_sources = raw_data_sources
         self.phone_number_uuid_table = phone_number_uuid_table
         self.timestamp_remappings = timestamp_remappings
@@ -275,6 +278,8 @@ class PipelineConfiguration(object):
 
     @classmethod
     def from_configuration_dict(cls, configuration_dict):
+        pipeline_name = configuration_dict["PipelineName"]
+
         raw_data_sources = []
         for raw_data_source in configuration_dict["RawDataSources"]:
             if raw_data_source["SourceType"] == "RapidPro":
@@ -311,7 +316,7 @@ class PipelineConfiguration(object):
         memory_profile_upload_url_prefix = configuration_dict["MemoryProfileUploadURLPrefix"]
         data_archive_upload_url_prefix = configuration_dict["DataArchiveUploadURLPrefix"]
 
-        return cls(raw_data_sources, phone_number_uuid_table, timestamp_remappings,
+        return cls(pipeline_name, raw_data_sources, phone_number_uuid_table, timestamp_remappings,
                    rapid_pro_key_remappings, project_start_date, project_end_date, filter_test_messages,
                    move_ws_messages, memory_profile_upload_url_prefix, data_archive_upload_url_prefix,
                    drive_upload_paths)
@@ -321,6 +326,8 @@ class PipelineConfiguration(object):
         return cls.from_configuration_dict(json.load(f))
 
     def validate(self):
+        validators.validate_string(self.pipeline_name, "pipeline_name")
+
         validators.validate_list(self.raw_data_sources, "raw_data_sources")
         for i, raw_data_source in enumerate(self.raw_data_sources):
             assert isinstance(raw_data_source, RawDataSource), f"raw_data_sources[{i}] is not of type of RawDataSource"

--- a/upload_logs.py
+++ b/upload_logs.py
@@ -36,6 +36,8 @@ if __name__ == "__main__":
     log.info("Loading Pipeline Configuration File...")
     with open(pipeline_configuration_file_path) as f:
         pipeline_configuration = PipelineConfiguration.from_configuration_file(f)
+    Logger.set_project_name(pipeline_configuration.pipeline_name)
+    log.debug(f"Pipeline name is {pipeline_configuration.pipeline_name}")
         
     memory_profile_upload_location = f"{pipeline_configuration.memory_profile_upload_url_prefix}{run_id}.profile"
     log.info(f"Uploading the memory profile from {memory_profile_file_path} to "


### PR DESCRIPTION
This is done by adding a PipelineName field to the configuration files, as has been done WUSC-KEEP-II and IMAQAL, then setting the project_name field in the Logger to use that as early in the pipeline stages as possible.

The main differences between this and the WUSC implementation are (a) pipeline_name is no longer optional. It needs to be compulsory so we can see it in the logs, and (b) moves it to the top of the configuration file, where I think it makes more sense to be.

Setting the project name in configuration means we can copy/paste the top level python scripts between projects without needing to remember to update all the hard-coded project names, so we can prepare future pipelines a bit quicker.