### PR TITLE
Log the Run Id at the start of the run_pipeline.sh script.

### DIFF
--- a/run_scripts/run_pipeline.sh
+++ b/run_scripts/run_pipeline.sh
@@ -25,6 +25,8 @@ DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 HASH=$(git rev-parse HEAD)
 RUN_ID="$DATE-$HASH"
 
+echo "Starting run with id '$RUN_ID'"
+
 ./1_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
 ./2_fetch_raw_data.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"


### PR DESCRIPTION
This makes it easier to resume failed runs, and easier to link logs with the data archives.